### PR TITLE
Teams assignment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,9 @@ Rails.application.configure do
   end
 
   # Store uploaded files locally
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
+  config.active_storage.variant_processor = :mini_magick
+  config.active_storage.service = :development
 
   # === MAILER SETTINGS (Yahoo SMTP) ===
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,11 @@ Rails.application.routes.draw do
       post '/login', to: 'sessions#create'
       delete '/logout', to: 'sessions#destroy'
       get '/verify', to: 'sessions#verify'
-      post '/refresh', to: 'sessions#refresh'        # ✅ Refresh token endpoint
+      post '/refresh', to: 'sessions#refresh'
       post '/register', to: 'registrations#create'
       get '/verify_admin', to: 'sessions#verify_admin'
-      post '/password/reset', to: 'passwords#reset'     
-      post '/password/update', to: 'passwords#update'    
+      post '/password/reset', to: 'passwords#reset'
+      post '/password/update', to: 'passwords#update'
 
       # Profile route
       resource :profile, only: [:show]
@@ -44,20 +44,22 @@ Rails.application.routes.draw do
           resources :problems, only: [:index]
         end
 
-        resources :teams, only: [:index, :show, :create, :update, :destroy] do
-          get 'users', on: :member
+        resources :teams, only: [:index, :show, :create, :update] do
+          member do
+            get 'users'
+            patch :deactivate # Added for soft deletion
+          end
         end
 
         resources :tickets, only: [:index, :show, :create, :update, :destroy] do
           collection do
             get :export
-            get :debug_visibility  # Added debug endpoint for troubleshooting ticket visibility
+            get :debug_visibility
           end
-        
           post :assign_to_user, on: :member
           post :escalate_to_problem, on: :member
           post :resolve, on: :member
-        end        
+        end
 
         resources :problems, only: [:index, :show, :create, :update, :destroy]
 
@@ -68,12 +70,12 @@ Rails.application.routes.draw do
     end
   end
 
-  # ✅ Root route returns simple confirmation for base GET /
+  # Root route returns simple confirmation for base GET /
   root to: proc {
     [200, { 'Content-Type' => 'application/json' }, [{ message: 'API is live' }.to_json]]
   }
 
-  # ✅ Catch-all fallback route for frontend
+  # Catch-all fallback route for frontend
   get '*path', to: proc {
     [404, { 'Content-Type' => 'application/json' }, [{ error: 'Not found' }.to_json]]
   }, constraints: ->(req) { !req.path.start_with?('/api', '/cable', '/rails') }

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -12,27 +12,19 @@ local:
 #   api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
 #   api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
 
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
+amazon_s3:
+  service: S3
+  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region: us-east-1
+  bucket: <%= Rails.application.credentials.dig(:aws, :bucket) %>
 
-# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name-<%= Rails.env %>
-
+azure:
+  service: AzureStorage
+  storage_account_name: <%= Rails.application.credentials.dig(:azure, :storage_account_name) %>
+  storage_access_key: <%= Rails.application.credentials.dig(:azure, :storage_access_key) %>
+  container: <%= Rails.application.credentials.dig(:azure, :container) %>
 # mirror:
 #   service: Mirror
 #   primary: local

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -2,29 +2,36 @@ test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>
 
-local:
+development:
   service: Disk
   root: <%= Rails.root.join("storage") %>
-
 # cloudinary:
 #   service: Cloudinary
 #   cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
 #   api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
 #   api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_own_bucket-<%= Rails.env %>
 
-amazon_s3:
-  service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: us-east-1
-  bucket: <%= Rails.application.credentials.dig(:aws, :bucket) %>
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket-<%= Rails.env %>
 
-azure:
-  service: AzureStorage
-  storage_account_name: <%= Rails.application.credentials.dig(:azure, :storage_account_name) %>
-  storage_access_key: <%= Rails.application.credentials.dig(:azure, :storage_access_key) %>
-  container: <%= Rails.application.credentials.dig(:azure, :container) %>
+# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name-<%= Rails.env %>
+
 # mirror:
 #   service: Mirror
 #   primary: local

--- a/db/migrate/20250830055739_add_deactivated_at_to_teams.rb
+++ b/db/migrate/20250830055739_add_deactivated_at_to_teams.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedAtToTeams < ActiveRecord::Migration[7.0]
+  def change
+    add_column :teams, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_28_201507) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_30_055739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -153,6 +153,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_28_201507) do
     t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deactivated_at"
   end
 
   create_table "tickets", force: :cascade do |t|


### PR DESCRIPTION
We Admin can now do a soft delete deactivation of teams
The Admin can now edit teams, remove or add more members

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Replace team deletion with a deactivate endpoint that unassigns members and related tickets and returns a confirmation.
  - Team creation now supports assigning users with validation and clearer errors.
  - Teams listing and retrieval now return only active teams; responses include deactivated_at and timezone-aware timestamps.
  - Non-admins can view/filter tickets only for their own team; unauthorized access returns 403.

- Chores
  - Development Active Storage config updated (environment key rename; variant processing enabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->