### PR TITLE
Fix for duplicate ticket numbers

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -134,6 +134,28 @@ module Api
         }, status: :ok
       end
 
+      def latest_ticket_number
+        scope = @organization.tickets
+        scope = scope.where(ticket_type: params[:ticket_type]) if params[:ticket_type].present?
+        scope = apply_filters(scope)
+
+        page = [params[:page].to_i, 1].max
+        per_page = [[params[:per_page].to_i, 1].max, 100].min
+
+        tickets = scope.paginate(page: page, per_page: per_page)
+
+        Rails.logger.info "Tickets query result for latest ticket numbers query #{params[:ticket_number]}: #{tickets.pluck(:ticket_number).inspect}"
+
+        render json: {
+          tickets: tickets.map { |t| ticket_attributes(t) },
+          pagination: {
+            current_page: tickets.current_page,
+            total_pages: tickets.total_pages,
+            total_entries: tickets.total_entries
+          }
+        }, status: :ok
+      end
+
       private
 
       def set_organization_from_subdomain

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
           get 'dashboard', to: 'dashboard#show'
           get 'profile', to: 'profiles#show'
           get 'tickets', to: 'organizations#tickets'
+          get 'latest_ticket_number', to: 'organizations#latest_ticket_number'
           get 'users', to: 'organizations#users'
           get 'settings', to: 'settings#index'
           put 'settings', to: 'settings#update'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new API endpoint to fetch the latest ticket numbers for a specific organization: GET /api/v1/organizations/:subdomain/latest_ticket_number.
  - Supports filtering (including by ticket type) and returns paginated results.
  - Response includes ticket details and pagination metadata (current_page, total_pages, total_entries) for easier client-side handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->